### PR TITLE
Remove Windows platform from distribution targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,9 +8,9 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Only build binaries marked with dist = true
 precisely-dist = ["mcp-probe"]
 # Skip checking whether cargo-dist should be run
@@ -20,6 +20,5 @@ allow-dirty = ["ci"]
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
-x86_64-pc-windows-msvc = "windows-2022"
 x86_64-apple-darwin = "macos-13"
 aarch64-apple-darwin = "macos-14"


### PR DESCRIPTION
- Remove x86_64-pc-windows-msvc from build targets
- Remove PowerShell installer (only shell installer needed)
- Remove Windows runner configuration
- Distribution now supports: Linux x64/ARM64, macOS Intel/Apple Silicon

🤖 Generated with [Claude Code](https://claude.ai/code)