### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the MCP Proxy TUI project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-07-01
+
+### Added
+- **Nix packaging support**: Added Nix flake configuration for reproducible builds across different platforms
+- **GitHub Pages deployment**: Automated deployment workflow for project landing page
+- **Project landing page**: Created index.html with project overview and documentation
+
+### Changed
+- **Project rename**: Renamed from `mcp-probe` to `mcp-trace` for better clarity
+- **UI improvements**: 
+  - Fixed tab visibility issues in the monitor interface
+  - Added context-aware help text that updates based on focused area
+  - Improved visual clarity of navigation modes and focus indicators
+- **Documentation updates**: Enhanced CLAUDE.md with clearer project guidelines
+
+### Fixed
+- **CI/CD**: Fixed GitHub Pages workflow to properly handle artifact uploads
+- **Nix CI**: Resolved formatting and clippy issues in Nix build process
+
 ## [0.1.0] - 2025-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Developing MCP servers can be challenging when you can't see what's happening un
 
 ```bash
 # macOS and Linux
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/zabirauf/mcp-trace/releases/download/v0.1.0/mcp-trace-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/zabirauf/mcp-trace/releases/download/v0.2.0/mcp-trace-installer.sh | sh
 ```
 
 ### Option 2: Download Prebuilt Binaries

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         commonArgs = {
           src = craneLib.cleanCargoSource (craneLib.path ./.);
           strictDeps = true;
-          version = "0.1.0";
+          version = "0.2.0";
           
           buildInputs = with pkgs; [
             # Add runtime dependencies if needed

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
             <p style="color: var(--text-secondary); margin-bottom: 20px;">
                 For macOS and Linux, run this command to automatically download and install:
             </p>
-            <div class="code-block">curl --proto '=https' --tlsv1.2 -LsSf https://github.com/zabirauf/mcp-trace/releases/download/v0.1.0/mcp-trace-installer.sh | sh</div>
+            <div class="code-block">curl --proto '=https' --tlsv1.2 -LsSf https://github.com/zabirauf/mcp-trace/releases/download/v0.2.0/mcp-trace-installer.sh | sh</div>
             
             <p style="color: var(--text-secondary); margin: 20px 0;">
                 For manual installation, download from 

--- a/mcp-common/Cargo.toml
+++ b/mcp-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-common"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/mcp-monitor/Cargo.toml
+++ b/mcp-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-monitor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [package.metadata.dist]

--- a/mcp-proxy/Cargo.toml
+++ b/mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [package.metadata.dist]

--- a/mcp-trace/Cargo.toml
+++ b/mcp-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-trace"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Terminal UI for monitoring Model Context Protocol (MCP) server traffic"
 authors = ["zabirauf"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-trace-e2e-tests"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump version to v0.2.0 across all crates
- Update CHANGELOG.md with changes since v0.1.0
- Update flake.nix version

## Changes since v0.1.0
- **Project rename**: mcp-probe → mcp-trace
- **Nix packaging support**: Added flake configuration for reproducible builds
- **GitHub Pages**: Added deployment workflow and landing page
- **UI improvements**: Fixed tab visibility and added context-aware help
- **Documentation**: Enhanced CLAUDE.md with project guidelines

## Test plan
- [ ] Verify all crate versions are updated to 0.2.0
- [ ] Confirm CHANGELOG.md accurately reflects changes
- [ ] Test build with `cargo build --release`
- [ ] Test Nix build with `nix build`
- [ ] Verify binaries work correctly after version bump

🤖 Generated with [Claude Code](https://claude.ai/code)